### PR TITLE
Fix tag parsing from comma-separated strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ The first time you use PDF annotation features, the necessary tools will be auto
 - `zotero_search_notes`: Search in notes and annotations (including PDF-extracted)
 - `zotero_create_note`: Create a new note for an item (beta feature)
 
+When providing tags (for example with `zotero_create_note` or batch tag updates),
+use a comma-separated string like `"cfrp, impact mechanics"` or supply a list of
+strings. Each tag will be applied individually.
+
 ## 🔍 Troubleshooting
 
 - **No results found**: Ensure Zotero is running and the local API is enabled

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 import os
 import uuid
 import tempfile
+import re
 
 from fastmcp import Context, FastMCP
 
@@ -20,11 +21,12 @@ from zotero_mcp.utils import format_creators
 
 
 def ensure_list(value: Union[str, List[str], None]) -> List[str]:
-    """Convert a string or list value to a list."""
+    """Convert a comma-separated string or list into a list of strings."""
     if value is None:
         return []
     if isinstance(value, str):
-        return [value]
+        parts = re.split(r"[;,]", value)
+        return [p.strip() for p in parts if p.strip()]
     if isinstance(value, list):
         return value
     return []


### PR DESCRIPTION
## Summary
- parse comma and semicolon separated strings in `ensure_list`
- document that tag inputs can be comma-separated lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436000d690832ebe9b5efcf628bb23