### PR TITLE
Force web API for modifying items

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,20 @@ For accessing your Zotero library via the web API (useful for remote setups):
 zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 ```
 
+**Note:** The local Zotero API is read-only for modifying items. Features such as
+batch tag updates or creating notes will automatically fall back to the web API
+when API credentials are available.
+
 ### Environment Variables
 
 - `ZOTERO_LOCAL=true`: Use the local Zotero API (default: false)
 - `ZOTERO_API_KEY`: Your Zotero API key (for web API)
 - `ZOTERO_LIBRARY_ID`: Your Zotero library ID (for web API)
 - `ZOTERO_LIBRARY_TYPE`: The type of library (user or group, default: user)
+
+If you set `ZOTERO_LOCAL=true` but also provide an API key and library ID, tools
+that modify items (like tag updates or note creation) will automatically use the
+web API.
 
 ### Command-Line Options
 
@@ -199,6 +207,10 @@ The first time you use PDF annotation features, the necessary tools will be auto
 - `zotero_get_notes`: Retrieve notes from your Zotero library
 - `zotero_search_notes`: Search in notes and annotations (including PDF-extracted)
 - `zotero_create_note`: Create a new note for an item (beta feature)
+
+When providing tags (for example with `zotero_create_note` or batch tag updates),
+use a comma-separated string like `"cfrp, impact mechanics"` or supply a list of
+strings. Each tag will be applied individually.
 
 ## 🔍 Troubleshooting
 

--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -27,7 +27,7 @@ class AttachmentDetails:
     content_type: str
 
 
-def get_zotero_client() -> zotero.Zotero:
+def get_zotero_client(local: Optional[bool] = None) -> zotero.Zotero:
     """
     Get authenticated Zotero client using environment variables.
     
@@ -40,7 +40,10 @@ def get_zotero_client() -> zotero.Zotero:
     library_id = os.getenv("ZOTERO_LIBRARY_ID")
     library_type = os.getenv("ZOTERO_LIBRARY_TYPE", "user")
     api_key = os.getenv("ZOTERO_API_KEY")
-    local = os.getenv("ZOTERO_LOCAL", "").lower() in ["true", "yes", "1"]
+
+    env_local = os.getenv("ZOTERO_LOCAL", "").lower() in ["true", "yes", "1"]
+    if local is None:
+        local = env_local
 
     # For local API, default to user ID 0 if not specified
     if local and not library_id:

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 import os
 import uuid
 import tempfile
+import re
 
 from fastmcp import Context, FastMCP
 
@@ -20,11 +21,12 @@ from zotero_mcp.utils import format_creators
 
 
 def ensure_list(value: Union[str, List[str], None]) -> List[str]:
-    """Convert a string or list value to a list."""
+    """Convert a comma-separated string or list into a list of strings."""
     if value is None:
         return []
     if isinstance(value, str):
-        return [value]
+        parts = re.split(r"[;,]", value)
+        return [p.strip() for p in parts if p.strip()]
     if isinstance(value, list):
         return value
     return []
@@ -641,6 +643,11 @@ def batch_update_tags(
         Summary of the batch update
     """
     try:
+        if os.environ.get("ZOTERO_LOCAL", "").lower() in ["true", "yes", "1"]:
+            ctx.info(
+                "ZOTERO_LOCAL is set but batch tag updates require write access. "
+                "Using the web API instead."
+            )
         if not query:
             return "Error: Search query cannot be empty"
 
@@ -651,7 +658,7 @@ def batch_update_tags(
             return "Error: You must specify either tags to add or tags to remove"
         
         ctx.info(f"Batch updating tags for items matching '{query}'")
-        zot = get_zotero_client()
+        zot = get_zotero_client(local=False)
         
         # Search for items matching the query
         zot.add_parameters(q=query, limit=limit)
@@ -1459,7 +1466,12 @@ def create_note(
     """
     try:
         ctx.info(f"Creating note for item {item_key}")
-        zot = get_zotero_client()
+        if os.environ.get("ZOTERO_LOCAL", "").lower() in ["true", "yes", "1"]:
+            ctx.info(
+                "ZOTERO_LOCAL is set but note creation requires write access. "
+                "Using the web API instead."
+            )
+        zot = get_zotero_client(local=False)
 
         tags = ensure_list(tags)
         


### PR DESCRIPTION
## Summary
- allow overriding `get_zotero_client`'s `local` mode
- always use the web API in `batch_update_tags` and `create_note`
- document automatic fallback to web API when item modification requires it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436000d690832ebe9b5efcf628bb23